### PR TITLE
Fix null header handling in DioResponseData

### DIFF
--- a/packages/ispectify_dio/lib/src/data/response.dart
+++ b/packages/ispectify_dio/lib/src/data/response.dart
@@ -17,6 +17,7 @@ class DioResponseData {
     Set<String>? ignoredValues,
     Set<String>? ignoredKeys,
   }) {
+    final headers = response?.headers;
     final map = <String, dynamic>{
       'request-options': redactor == null
           ? requestData.toJson()
@@ -42,7 +43,7 @@ class DioResponseData {
                 },
               )
               .toList(),
-      'headers': response?.headers.map,
+      'headers': headers == null ? null : headers.map,
     };
 
     if (redactor == null) {

--- a/packages/ispectify_dio/test/response_null_test.dart
+++ b/packages/ispectify_dio/test/response_null_test.dart
@@ -22,4 +22,22 @@ void main() {
     expect(json['headers'], isNull);
     expect(json['redirects'], isNull);
   });
+
+  test('DioResponseData.toJson handles DioException without response', () {
+    final dioException = DioException(
+      requestOptions: RequestOptions(path: '/exception'),
+    );
+    final data = DioResponseData(
+      response: dioException.response,
+      requestData: DioRequestData(dioException.requestOptions),
+    );
+
+    late Map<String, dynamic> json;
+    expect(
+      () => json = data.toJson(redactor: RedactionService()),
+      returnsNormally,
+    );
+
+    expect(json['headers'], anyOf(isNull, isEmpty));
+  });
 }


### PR DESCRIPTION
## Summary
- guard header serialization by caching response headers before use
- ensure missing headers serialize as null instead of throwing
- cover DioException without a response to verify serialization stays safe

## Testing
- dart test packages/ispectify_dio *(fails: dart command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4f4bca48832fbff675b6de7acb4a