### PR TITLE
Feat/refactoring

### DIFF
--- a/web_logs_viewer/lib/main.dart
+++ b/web_logs_viewer/lib/main.dart
@@ -10,8 +10,6 @@ import 'package:web_logs_viewer/src/features/demo/presentation/demo_screen.dart'
 
 import 'src/features/file_viewer/presentation/pages/file_viewer_page.dart';
 
-final observer = ISpectNavigatorObserver();
-
 void main() {
   final logger = ISpectifyFlutter.init();
   ISpect.run(
@@ -38,6 +36,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   final draggablePanelController = DraggablePanelController();
+  final observer = ISpectNavigatorObserver();
 
   @override
   void dispose() {


### PR DESCRIPTION
This pull request makes several updates to the `web_logs_viewer/lib/main.dart` file, primarily focusing on application theme configuration and code organization. The most important changes include setting the app to always use the light theme, removing the dark theme configuration, and relocating the navigator observer to improve code structure.

**Theme configuration:**

* The app is now explicitly set to use the light theme by adding `themeMode: ThemeMode.light` to the `MaterialApp` configuration.
* The dark theme configuration has been removed, so the app will no longer support dark mode.

**Code organization:**

* The `ISpectNavigatorObserver` instance was moved from the global scope to be a member of the `_MyAppState` class, improving encapsulation and code clarity. [[1]](diffhunk://#diff-f43240be3bd8b0ae45441bf29ded6e57dcd79b0b9bfb8aed4bd663eba2d25f5bL13-L14) [[2]](diffhunk://#diff-f43240be3bd8b0ae45441bf29ded6e57dcd79b0b9bfb8aed4bd663eba2d25f5bR39)

## Summary by Sourcery

Enforce light-only theme and encapsulate navigator observer within the app state

Enhancements:
- Set themeMode to light and remove dark theme configuration
- Relocate ISpectNavigatorObserver instance into _MyAppState for improved encapsulation