### PR TITLE
Chore/http interceptor v3 migration

### DIFF
--- a/.github/workflows/sync_versions_and_changelogs.yml
+++ b/.github/workflows/sync_versions_and_changelogs.yml
@@ -4,6 +4,7 @@ on:
    push:
       branches-ignore:
          - "auto/sync/**"
+         - "dependabot/**"
       paths:
          - "CHANGELOG.md"
          - "ROADMAP.md"

--- a/packages/ispect/example/pubspec.yaml
+++ b/packages/ispect/example/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   ws: ^1.0.0
   http: ^1.3.0
   flutter_bloc: ^9.1.0
-  http_interceptor: ^2.0.0
+  http_interceptor: ^3.0.0
   flutter_riverpod: ^2.5.1
   share_plus: ^12.0.0
   open_filex: ^4.7.0

--- a/packages/ispectify_http/lib/src/interceptor.dart
+++ b/packages/ispectify_http/lib/src/interceptor.dart
@@ -1,15 +1,18 @@
+import 'dart:async';
+
 import 'package:http_interceptor/http_interceptor.dart';
 import 'package:ispectify/ispectify.dart';
 import 'package:ispectify_http/src/data/_data.dart';
 import 'package:ispectify_http/src/settings.dart';
 
 /// HTTP client interceptor that logs requests/responses via the trace API.
-class ISpectHttpInterceptor extends InterceptorContract
+class ISpectHttpInterceptor
     with
         NetworkLoggerMixin,
         NetworkRedactionMixin,
         NetworkConfigurationMixin,
-        BaseNetworkInterceptor {
+        BaseNetworkInterceptor
+    implements HttpInterceptor {
   ISpectHttpInterceptor({
     ISpectLogger? logger,
     ISpectHttpInterceptorSettings settings =
@@ -44,6 +47,13 @@ class ISpectHttpInterceptor extends InterceptorContract
   void applyConfigurableSettings(BaseNetworkInterceptorSettings updated) {
     _settings = updated as ISpectHttpInterceptorSettings;
   }
+
+  @override
+  FutureOr<bool> shouldInterceptRequest({required BaseRequest request}) => true;
+
+  @override
+  FutureOr<bool> shouldInterceptResponse({required BaseResponse response}) =>
+      true;
 
   @override
   Future<BaseRequest> interceptRequest({

--- a/packages/ispectify_http/pubspec.yaml
+++ b/packages/ispectify_http/pubspec.yaml
@@ -14,7 +14,7 @@ dependency_overrides:
 
 dependencies:
   http: ^1.5.0
-  http_interceptor: ^2.0.0
+  http_interceptor: ^3.0.0
   ispectify: ^5.0.0
 
 dev_dependencies:

--- a/web_logs_viewer/lib/main.dart
+++ b/web_logs_viewer/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:ispect/ispect.dart';
 import 'package:ispectify_bloc/ispectify_bloc.dart';
 import 'package:ispectify_dio/ispectify_dio.dart';
+import 'package:http_interceptor/http_interceptor.dart';
 import 'package:ispectify_http/ispectify_http.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:share_plus/share_plus.dart';
@@ -24,7 +25,9 @@ void main() {
     },
     onInit: () {
       Bloc.observer = ISpectBlocObserver(logger: logger);
-      client.interceptors.add(ISpectHttpInterceptor(logger: logger));
+      client = InterceptedClient.build(
+        interceptors: [ISpectHttpInterceptor(logger: logger)],
+      );
       dio.interceptors.add(ISpectDioInterceptor(logger: logger));
       dummyDio.interceptors.add(ISpectDioInterceptor(logger: logger));
     },

--- a/web_logs_viewer/lib/src/features/demo/presentation/demo_screen.dart
+++ b/web_logs_viewer/lib/src/features/demo/presentation/demo_screen.dart
@@ -20,8 +20,7 @@ final Dio dio = Dio(
   BaseOptions(baseUrl: 'https://jsonplaceholder.typicode.com'),
 );
 
-final http_interceptor.InterceptedClient client =
-    http_interceptor.InterceptedClient.build(interceptors: []);
+late final http_interceptor.InterceptedClient client;
 
 final Dio dummyDio = Dio(BaseOptions(baseUrl: 'https://api.escuelajs.co'));
 

--- a/web_logs_viewer/pubspec.yaml
+++ b/web_logs_viewer/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   ws: ^1.0.0
   http: ^1.3.0
   flutter_bloc: ^9.1.0
-  http_interceptor: ^2.0.0
+  http_interceptor: ^3.0.0
   flutter_riverpod: ^2.5.1
   share_plus: ^12.0.0
   open_filex: ^4.7.0


### PR DESCRIPTION
## Summary by Sourcery

Migrate HTTP interceptor usage and configuration to be compatible with http_interceptor v3 across the packages and example app.

Enhancements:
- Update ISpectHttpInterceptor to implement the new HttpInterceptor interface and always intercept requests and responses.
- Adjust example web_logs_viewer client setup to use InterceptedClient.build with the custom interceptor and lazy initialization.
- Exclude Dependabot branches from the sync_versions_and_changelogs GitHub workflow.

Build:
- Bump http_interceptor dependency to ^3.0.0 in relevant pubspec.yaml files.