### PR TITLE
ci: restrict sync workflow to main and develop

### DIFF
--- a/.github/workflows/sync_versions_and_changelogs.yml
+++ b/.github/workflows/sync_versions_and_changelogs.yml
@@ -2,9 +2,9 @@ name: Sync Versions, Changelogs, and READMEs
 
 on:
    push:
-      branches-ignore:
-         - "auto/sync/**"
-         - "dependabot/**"
+      branches:
+         - main
+         - develop
       paths:
          - "CHANGELOG.md"
          - "ROADMAP.md"


### PR DESCRIPTION
The earlier `branches-ignore` list still triggered the workflow on every other branch push, including feature branches. That is semantically wrong (versions are still in flux on feature branches) and produced spurious `peter-evans/create-pull-request` failures. Switch to an allowlist of main/develop so the workflow only runs where the version sync actually belongs.

## Summary by Sourcery

CI:
- Limit the sync_versions_and_changelogs workflow trigger to the main and develop branches instead of all branches except a few ignored ones.