### PR TITLE
feat(navigation): add showArgumentValues option to route observer

### DIFF
--- a/packages/ispect/lib/src/common/observers/route_observer.dart
+++ b/packages/ispect/lib/src/common/observers/route_observer.dart
@@ -28,6 +28,9 @@ class ISpectNavigatorObserver extends NavigatorObserver {
   /// - `isLogPages`: Whether to log page navigations.
   /// - `isLogModals`: Whether to log modal transitions.
   /// - `isLogOtherTypes`: Whether to log other navigation types.
+  /// - `showArgumentValues`: When false (default), logs only argument key
+  ///   names for maps, or the runtime type for other objects. When true,
+  ///   includes full argument values.
   ISpectNavigatorObserver({
     this.isLogGestures = false,
     this.isLogPages = true,
@@ -41,8 +44,12 @@ class ISpectNavigatorObserver extends NavigatorObserver {
     this.onStartUserGesture,
     this.onStopUserGesture,
     this.maxTransitions = 200,
-    this.enableArgumentRedaction = true,
-  });
+    bool showArgumentValues = false,
+    @Deprecated('Use showArgumentValues instead.')
+    bool? enableArgumentRedaction,
+  }) : showArgumentValues = enableArgumentRedaction == null
+            ? showArgumentValues
+            : !enableArgumentRedaction;
 
   /// The most recently installed `ISpectNavigatorObserver`.
   ///
@@ -135,10 +142,10 @@ class ISpectNavigatorObserver extends NavigatorObserver {
       onStartUserGesture;
   final VoidCallback? onStopUserGesture;
 
-  /// When true, route arguments are redacted in log messages by showing
-  /// only their type and key names (no values). Defaults to true for security.
-  /// Set to false to include full argument details in logs.
-  final bool enableArgumentRedaction;
+  /// When true, route argument values are included in log messages.
+  /// Defaults to false so only parameter key names are logged.
+  /// Setting [ISpectRedaction.enabled] to false shows full values globally.
+  final bool showArgumentValues;
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -204,7 +211,7 @@ class ISpectNavigatorObserver extends NavigatorObserver {
 
     addTransition(transition);
 
-    final logMessage = _buildLogMessage(type, route, previousRoute);
+    final logMessage = buildLogMessage(type, route, previousRoute);
     ISpect.logger.route(logMessage, transitionId: correlationId);
   }
 
@@ -268,7 +275,8 @@ class ISpectNavigatorObserver extends NavigatorObserver {
   }
 
   /// Builds a structured log message for route transitions.
-  String _buildLogMessage(
+  @visibleForTesting
+  String buildLogMessage(
     TransitionType type,
     Route<dynamic>? route,
     Route<dynamic>? previousRoute,
@@ -282,23 +290,22 @@ class ISpectNavigatorObserver extends NavigatorObserver {
     buffer.writeln(
         '${type.title} | $previousRouteName ($previousRouteType) → $routeName ($routeType)');
 
-    // Arguments info — redacted by default (only type and key names). The
-    // global ISpectRedaction kill-switch overrides the per-observer flag.
-    final redactArguments = enableArgumentRedaction && ISpectRedaction.enabled;
+    final showValues = showArgumentValues || !ISpectRedaction.enabled;
     switch (route?.settings.arguments) {
       case null:
         break;
-      case final Map<String, dynamic> args:
-        if (redactArguments) {
-          buffer.writeln('Arguments: {${args.keys.join(', ')}}');
-        } else {
+      case final Map<dynamic, dynamic> args:
+        final keys = args.keys.map((key) => key.toString()).join(', ');
+        if (showValues) {
           buffer.writeln('Arguments: $args');
+        } else {
+          buffer.writeln('Arguments: {$keys}');
         }
       case final Object args:
-        if (redactArguments) {
-          buffer.writeln('Arguments: (${args.runtimeType})');
-        } else {
+        if (showValues) {
           buffer.writeln('Arguments: $args');
+        } else {
+          buffer.writeln('Arguments: (${args.runtimeType})');
         }
     }
 

--- a/packages/ispect/test/observers/route_observer_log_message_test.dart
+++ b/packages/ispect/test/observers/route_observer_log_message_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ispect/src/common/observers/route_observer.dart';
+import 'package:ispect/src/common/observers/transition.dart';
+import 'package:ispectify/ispectify.dart';
+
+void main() {
+  group('ISpectNavigatorObserver log message', () {
+    tearDown(() => ISpectRedaction.enabled = true);
+
+    test('shows only argument keys when showArgumentValues is false', () {
+      final observer = ISpectNavigatorObserver();
+      final route = _route(
+        arguments: const {'token': 'secret', 'screen': 'profile'},
+      );
+
+      final message = observer.buildLogMessage(
+        TransitionType.push,
+        route,
+        null,
+      );
+
+      expect(message, contains('Arguments: {token, screen}'));
+      expect(message, isNot(contains('secret')));
+      expect(message, isNot(contains(': profile')));
+    });
+
+    test('shows argument values when showArgumentValues is true', () {
+      final observer = ISpectNavigatorObserver(showArgumentValues: true);
+      final route = _route(
+        arguments: const {'token': 'secret', 'screen': 'profile'},
+      );
+
+      final message = observer.buildLogMessage(
+        TransitionType.push,
+        route,
+        null,
+      );
+
+      expect(message, contains('secret'));
+      expect(message, contains('profile'));
+    });
+
+    test('shows typed argument runtime type when values are hidden', () {
+      final observer = ISpectNavigatorObserver();
+      final route = _route(arguments: const _TypedRouteArgs(id: 1));
+
+      final message = observer.buildLogMessage(
+        TransitionType.push,
+        route,
+        null,
+      );
+
+      expect(message, contains('Arguments: (_TypedRouteArgs)'));
+    });
+
+    test('shows values when global redaction is disabled', () {
+      ISpectRedaction.enabled = false;
+      final observer = ISpectNavigatorObserver();
+      final route = _route(arguments: const {'token': 'secret'});
+
+      final message = observer.buildLogMessage(
+        TransitionType.push,
+        route,
+        null,
+      );
+
+      expect(message, contains('secret'));
+    });
+  });
+}
+
+Route<dynamic> _route({Object? arguments}) => MaterialPageRoute<void>(
+      settings: RouteSettings(name: '/profile', arguments: arguments),
+      builder: (_) => const SizedBox.shrink(),
+    );
+
+class _TypedRouteArgs {
+  const _TypedRouteArgs({required this.id});
+
+  final int id;
+}


### PR DESCRIPTION
Sorry for bothering you to review this without a prior issue — these changes felt necessary to improve the package 🙂

## Summary
- Adds `showArgumentValues` to `ISpectNavigatorObserver` (default `false`) so route logs show only argument keys for maps, or the runtime type for other objects, unless values are explicitly opted in.
- Deprecates the `enableArgumentRedaction` constructor parameter in favor of the clearer `showArgumentValues` naming (`enableArgumentRedaction: false` → `showArgumentValues: true`).
- Preserves the global `ISpectRedaction.enabled` kill-switch: setting it to `false` still logs full argument values.
- Adds regression tests for the new logging behavior.

## Test plan
- [x] `flutter test test/observers/route_observer_log_message_test.dart`
- [ ] Verify navigation logs in the example app show `Arguments: {key1, key2}` by default
- [ ] Verify `ISpectNavigatorObserver(showArgumentValues: true)` logs full argument values
- [ ] Verify `ISpectRedaction.enabled = false` still bypasses redaction globally


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add configurable control over route argument value logging and update tests accordingly.

New Features:
- Introduce a showArgumentValues option on ISpectNavigatorObserver to control whether route argument values are included in logs.

Enhancements:
- Adjust route argument logging to default to redacting values while still respecting the global ISpectRedaction kill-switch.
- Relax route argument map typing in log message construction to support non-string keys and improve key-only logging.

Tests:
- Add route observer log message tests covering key-only argument logging, value inclusion, typed argument handling, and global redaction overrides.